### PR TITLE
Brazilian string language translations and permission dialog conversion to string

### DIFF
--- a/app/src/main/res/layout/dialogpermission.xml
+++ b/app/src/main/res/layout/dialogpermission.xml
@@ -27,16 +27,16 @@
         android:paddingBottom="24dp"
         android:textColor="?android:textColorPrimary"
         android:textSize="20sp"
-        android:text="Grant the all file access Permission to Make Sparkles IDE works Correctly " />
+        android:text="@string/permission_dialog_text"
 
     <TextView
         android:id="@android:id/button1"
         style="@style/GrantPermissionsButtons.Top"
-        android:text="Grant" />
+        android:text="@string/Grant" />
 
     <TextView
         android:id="@android:id/button3"
         style="@style/GrantPermissionsButtons.Buttom"
-        android:text="Deny" />
+        android:text="@string/Deny" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialogpermission.xml
+++ b/app/src/main/res/layout/dialogpermission.xml
@@ -27,7 +27,7 @@
         android:paddingBottom="24dp"
         android:textColor="?android:textColorPrimary"
         android:textSize="20sp"
-        android:text="@string/permission_dialog_text"
+        android:text="@string/permission_dialog_text" />
 
     <TextView
         android:id="@android:id/button1"

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -19,14 +19,42 @@
   <string name="about_tag_developer">Desenvolvedor</string>
   <string name="tooltip_settings">Configurações</string>
   <string name="tooltip_terminal">Abrir terminal</string>
-  <string name="tooltip_new_file">Novo arquivo</string>
+  <string name="tooltip_new_file">Novo Arquivo</string>
   <string name="tooltip_search">Pesquisar no código</string>
   <string name="monet_title">Usar cores dinâmicas</string>
   <string name="monet_desc">Usar a paleta de cores do seu dispositivo em vez de branco e preto</string>
   <string name="need_restart">Precisa reiniciar</string>
+  <string name="about_tag_promote">Promotor</string>
+  <string name="about_tag_designer">Designer</string>
+  <string name="amoled_title">Tema noturno</string>
+  <string name="amoled_desc">Tema amoled preto</string>
+  <string name="art_phrase">Transformando códigos em histórias que mudam vidas✨️</string>
+  <string name="nex_phrase">Um cara à moda antiga entre os modernos</string>
+  <string name="omer_phrase">Proprietário do POPMods</string>
+  <string name="optim_phrase">Proprietário do AndroBusket</string>
+  <string name="zg_phrase">Um Designer de Material</string>
+  <string name="common_word_result">Resultado</string>
+  <string name="common_word_ok">Ok</string>
+  <string name="common_word_copy">Copiar</string>
+  <string name="apper_uimode">Definir Modo de UI:</string>
+  <string name="editor_theme">Tema do Editor</string>
+  <string name="editor_theme_desc">Escolher o Tema do Editor Sora</string>
+  <string name="editor_wordwrap">Quebra de Linha</string>
+  <string name="editor_wordwrap_desc">Ativar Quebra de Linha do Sora</string>
+  <string name="editor_fl">Mostrar Número da Primeira Linha</string>
+  <string name="editor_fl_desc">Mostrar ou ocultar o número da primeira linha</string>
+  <string name="editor_overscroll">Deslize Excedente</string>
+  <string name="editor_overscroll_desc">Ativar Deslize Excedente do Sora</string>
+  <string name="editor_ln">Mostrar Números de Linha</string>
+  <string name="editor_ln_desc">Mostrar ou ocultar os números de linha</string>
+  <string name="editor_toolbar">Mostrar Barra de Ferramentas</string>
+  <string name="editor_toolbar_desc">Mostrar ou ocultar a Barra de Ferramentas</string>
+  <string name="editor_tab">Guias (Atualmente indisponível)</string>
+  <string name="editor_tab_desc">Usar modo de guias no Sparkles</string>
+  <string name="editor_title">Formatação</string>
+  <string name="editor_theme_title">Tema do Editor Sora</string>
 
-  <!--TEAM BIO-->
-
+  <!-- TEAM BIO -->
   <string name="syntaxspin_phrase">Um Amante de Material You e Desenvolvedor Android/Web</string>
   <string name="yamenher_phrase">Um criador de coisas legais e úteis</string>
   <string name="trindadedev_phrase">Eu uso o Jetpack Compose, a propósito</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -53,6 +53,9 @@
   <string name="editor_tab_desc">Usar modo de guias no Sparkles</string>
   <string name="editor_title">Formatação</string>
   <string name="editor_theme_title">Tema do Editor Sora</string>
+  <string name="permission_dialog_text">Conceder a todos os arquivos permissão de acesso para fazer o Sparkles IDE funcionar corretamente</string>
+  <string name="Grant">Conceder</string>
+  <string name="Deny">Negar</string>
 
   <!-- TEAM BIO -->
   <string name="syntaxspin_phrase">Um Amante de Material You e Desenvolvedor Android/Web</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,10 @@
   <string name="tooltip_terminal">Open terminal</string>
   <string name="tooltip_new_file">New File</string>
   <string name="tooltip_search">Search in code</string>
+  <string name="permission_dialog_text">Grant the all file access Permission to Make Sparkles IDE work Correctly</string>
+  <string name="Grant">Grant</string>
+  <string name="Deny">Deny</string>
+  
  <!--Appearance Settings-->
   <string name="monet_title">Use Dynamic Colors</string>
   <string name="monet_desc">Use your device color palette instead black and white</string>


### PR DESCRIPTION
> [!note]
> Now the permission dialog is a string, making it easier for other contributors to translate it into their language.

![Screenshot_20250226-142259](https://github.com/user-attachments/assets/4203eba0-415f-4b2f-84aa-d42305e922c3)

> [!note]
> Translation of new languages into Brazilian Portuguese.

![Screenshot_20250226-142317](https://github.com/user-attachments/assets/78880f87-58df-48e0-bf16-c2190ed3a304)

---

> [!important]
> This PR is safe and does not conflict with other files or cause problems during execution.